### PR TITLE
Copy ibm-ups files from phosphor-power

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
 # ibm-ups
+
+## Overview
+
+An Uninterruptible Power Supply (UPS) provides a temporary power source if AC
+(wall) power is lost.
+
+The UPS contains a battery that can support a system for a brief period (such
+as 30 minutes). The UPS allows the system to keep running during a short power
+outage. During a long outage, the UPS gives the operating system time to
+perform an orderly shutdown.
+
+The UPS must be connected to a USB port using an IBM "System Port Converter
+Cable". At most one UPS can be attached using a USB port.
+
+The ibm-ups application monitors the UPS. ibm-ups publishes the UPS status on
+D-Bus. The chassis state manager application utilizes the D-Bus information.
+PLDM creates a composite state sensor based on the D-Bus information. The PLDM
+sensor makes the UPS status available to the operating system.
+
+## Build
+
+To build the repository:
+
+```sh
+  meson setup build
+  ninja -C build
+```
+
+To clean the repository and remove all build output:
+
+```sh
+  rm -rf build
+```

--- a/device.hpp
+++ b/device.hpp
@@ -1,0 +1,90 @@
+/**
+ * Copyright © 2021 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <org/freedesktop/UPower/Device/server.hpp>
+#include <sdbusplus/server/object.hpp>
+
+/**
+ * This file contains data types and constants related to the
+ * org.freedesktop.UPower.Device interface.
+ */
+
+namespace ibm_ups
+{
+
+/**
+ * Define simple name for the generated C++ class that implements the
+ * org.freedesktop.UPower.Device interface.
+ */
+using DeviceInterface = sdbusplus::org::freedesktop::UPower::server::Device;
+
+/**
+ * Define simple name for the sdbusplus object_t class that implements all
+ * the necessary D-Bus interfaces via templates/multiple inheritance.
+ */
+using DeviceObject = sdbusplus::server::object_t<DeviceInterface>;
+
+namespace device
+{
+
+/**
+ * Defined values for the Type property.
+ */
+namespace type
+{
+constexpr auto Unknown = 0;
+constexpr auto LinePower = 1;
+constexpr auto Battery = 2;
+constexpr auto Ups = 3;
+constexpr auto Monitor = 4;
+constexpr auto Mouse = 5;
+constexpr auto Keyboard = 6;
+constexpr auto Pda = 7;
+constexpr auto Phone = 8;
+} // namespace type
+
+/**
+ * Defined values for the State property.
+ */
+namespace state
+{
+constexpr auto Unknown = 0;
+constexpr auto Charging = 1;
+constexpr auto Discharging = 2;
+constexpr auto Empty = 3;
+constexpr auto FullyCharged = 4;
+constexpr auto PendingCharge = 5;
+constexpr auto PendingDischarge = 6;
+} // namespace state
+
+/**
+ * Defined values for the BatteryLevel property.
+ */
+namespace battery_level
+{
+constexpr auto Unknown = 0;
+constexpr auto None = 1;
+constexpr auto Low = 3;
+constexpr auto Critical = 4;
+constexpr auto Normal = 6;
+constexpr auto High = 7;
+constexpr auto Full = 8;
+} // namespace battery_level
+
+} // namespace device
+
+} // namespace ibm_ups

--- a/error_logging.cpp
+++ b/error_logging.cpp
@@ -1,0 +1,73 @@
+/**
+ * Copyright © 2022 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "error_logging.hpp"
+
+#include "journal.hpp"
+
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <sdbusplus/message.hpp>
+
+#include <exception>
+
+namespace ibm_ups::error_logging
+{
+
+void logBatteryDischarging(sdbusplus::bus::bus& bus,
+                           const std::string& devicePath)
+{
+    std::string message{
+        "xyz.openbmc_project.Power.UPS.Error.Battery.Discharging"};
+    std::map<std::string, std::string> additionalData{};
+    additionalData.emplace("UPS_DEVICE_PATH", devicePath);
+    logError(bus, message, Entry::Level::Informational, additionalData);
+}
+
+void logBatteryLow(sdbusplus::bus::bus& bus, const std::string& devicePath)
+{
+    std::string message{"xyz.openbmc_project.Power.UPS.Error.Battery.Low"};
+    std::map<std::string, std::string> additionalData{};
+    additionalData.emplace("UPS_DEVICE_PATH", devicePath);
+    logError(bus, message, Entry::Level::Informational, additionalData);
+}
+
+void logError(sdbusplus::bus::bus& bus, const std::string& message,
+              Entry::Level severity,
+              std::map<std::string, std::string>& additionalData)
+{
+    try
+    {
+        additionalData.emplace("_PID", std::to_string(getpid()));
+
+        // Call D-Bus method to create error log
+        const char* service = "xyz.openbmc_project.Logging";
+        const char* objPath = "/xyz/openbmc_project/logging";
+        const char* interface = "xyz.openbmc_project.Logging.Create";
+        const char* method = "Create";
+        auto reqMsg = bus.new_method_call(service, objPath, interface, method);
+        reqMsg.append(message, severity, additionalData);
+        auto respMsg = bus.call(reqMsg);
+    }
+    catch (const std::exception& e)
+    {
+        journal::logError(e.what());
+        journal::logError("Unable to log error " + message);
+    }
+}
+
+} // namespace ibm_ups::error_logging

--- a/error_logging.hpp
+++ b/error_logging.hpp
@@ -1,0 +1,65 @@
+/**
+ * Copyright © 2022 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "xyz/openbmc_project/Logging/Entry/server.hpp"
+
+#include <sdbusplus/bus.hpp>
+
+#include <map>
+#include <string>
+
+/**
+ * This namespace contains utility functions to simplify logging UPS errors.
+ */
+namespace ibm_ups::error_logging
+{
+using namespace sdbusplus::xyz::openbmc_project::Logging::server;
+
+/**
+ * Log an error indicating that the UPS battery is discharging due to a utility
+ * failure.
+ *
+ * @param bus D-Bus bus object
+ * @param devicePath path to the UPS device
+ */
+void logBatteryDischarging(sdbusplus::bus::bus& bus,
+                           const std::string& devicePath);
+
+/**
+ * Log an error indicating that the UPS battery level is low.
+ *
+ * @param bus D-Bus bus object
+ * @param devicePath path to the UPS device
+ */
+void logBatteryLow(sdbusplus::bus::bus& bus, const std::string& devicePath);
+
+/**
+ * Log an error using the D-Bus Create method.
+ *
+ * If logging fails, a message is written to the journal but an exception is
+ * not thrown.
+ *
+ * @param bus D-Bus bus object
+ * @param message Message property of the error log entry
+ * @param severity Severity property of the error log entry
+ * @param additionalData AdditionalData property of the error log entry
+ */
+void logError(sdbusplus::bus::bus& bus, const std::string& message,
+              Entry::Level severity,
+              std::map<std::string, std::string>& additionalData);
+
+} // namespace ibm_ups::error_logging

--- a/ibm-ups.service
+++ b/ibm-ups.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=IBM UPS monitor
+Before=xyz.openbmc_project.State.Chassis@0.service
+
+[Service]
+Restart=on-failure
+ExecStart=/usr/bin/ibm-ups
+Type=dbus
+BusName=xyz.openbmc_project.Power.IBMUPS
+
+[Install]
+WantedBy=multi-user.target

--- a/journal.hpp
+++ b/journal.hpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright © 2022 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <phosphor-logging/log.hpp>
+
+#include <string>
+
+/**
+ * This namespace contains utility functions to simplify writing messages to the
+ * system journal.
+ */
+namespace ibm_ups::journal
+{
+
+/**
+ * Logs an error message in the system journal.
+ *
+ * @param message message to log
+ */
+inline void logError(const std::string& message)
+{
+    using namespace phosphor::logging;
+    log<level::ERR>(message.c_str());
+}
+
+/**
+ * Logs an informational message in the system journal.
+ *
+ * @param message message to log
+ */
+inline void logInfo(const std::string& message)
+{
+    using namespace phosphor::logging;
+    log<level::INFO>(message.c_str());
+}
+
+} // namespace ibm_ups::journal

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,74 @@
+/**
+ * Copyright © 2021 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "monitor.hpp"
+
+#include <CLI/CLI.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdeventplus/event.hpp>
+#include <stdplus/signal.hpp>
+
+#include <exception>
+#include <iostream>
+
+using namespace ibm_ups;
+
+int main(int argc, const char* argv[])
+{
+    int rc{0};
+    try
+    {
+        // Block SIGHUP and SIGCONT signals that may be sent by UPS driver
+        stdplus::signal::block(SIGHUP);
+        stdplus::signal::block(SIGCONT);
+
+        // Parse command line parameters (if any)
+        CLI::App app{"IBM UPS Monitor"};
+        bool isPollingDisabled{false};
+        app.add_flag("--no-poll", isPollingDisabled,
+                     "Do not poll the UPS device for status");
+        CLI11_PARSE(app, argc, argv);
+
+        // Create D-Bus bus and event
+        auto bus = sdbusplus::bus::new_default();
+        auto event = sdeventplus::Event::get_default();
+        bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
+
+        // Create UPS monitor
+        Monitor monitor{bus, event};
+        if (isPollingDisabled)
+        {
+            // Disable monitoring/polling of the UPS device
+            monitor.disable();
+        }
+
+        // Obtain D-Bus service name
+        bus.request_name("xyz.openbmc_project.Power.IBMUPS");
+
+        rc = event.loop();
+    }
+    catch (const std::exception& e)
+    {
+        rc = 1;
+        std::cerr << e.what() << std::endl;
+    }
+    catch (...)
+    {
+        rc = 1;
+        std::cerr << "Unknown exception occurred." << std::endl;
+    }
+    return rc;
+}

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,48 @@
+project(
+    'ibm-ups',
+    'cpp',
+    default_options: [
+        'warning_level=3',
+        'werror=true',
+        'cpp_std=c++23',
+        'buildtype=debugoptimized',
+        'prefix=/usr'
+    ],
+    license: 'Apache-2.0',
+    version: '1.0',
+    meson_version: '>=1.1.1',
+)
+
+phosphor_dbus_interfaces = dependency('phosphor-dbus-interfaces')
+phosphor_logging = dependency('phosphor-logging')
+sdbusplus = dependency('sdbusplus')
+sdeventplus = dependency('sdeventplus')
+stdplus = dependency('stdplus')
+
+cxx = meson.get_compiler('cpp')
+if cxx.has_header('CLI/CLI.hpp')
+    cli11_dep = declare_dependency()
+else
+    cli11_dep = dependency('CLI11')
+endif
+
+systemd = dependency('systemd')
+servicedir = systemd.get_variable('systemdsystemunitdir')
+fs = import('fs')
+fs.copyfile('ibm-ups.service', install: true, install_dir: servicedir)
+
+ibm_ups = executable(
+    'ibm-ups',
+    'error_logging.cpp',
+    'main.cpp',
+    'monitor.cpp',
+    'ups.cpp',
+    dependencies: [
+        phosphor_dbus_interfaces,
+        phosphor_logging,
+        sdbusplus,
+        sdeventplus,
+        stdplus
+    ],
+    install: true
+)

--- a/monitor.cpp
+++ b/monitor.cpp
@@ -1,0 +1,37 @@
+/**
+ * Copyright © 2021 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "monitor.hpp"
+
+#include <functional>
+
+namespace ibm_ups
+{
+
+/**
+ * Root D-Bus object path for this application.
+ */
+constexpr auto rootObjectPath = "/org/freedesktop/UPower";
+
+Monitor::Monitor(sdbusplus::bus::bus& bus, const sdeventplus::Event& event) :
+    bus{bus}, eventLoop{event}, manager{bus, rootObjectPath}, ups{bus},
+    timer{event, std::bind(&Monitor::timerExpired, this)}
+{
+    // Start timer that polls UPS device for current status
+    startTimer();
+}
+
+} // namespace ibm_ups

--- a/monitor.hpp
+++ b/monitor.hpp
@@ -1,0 +1,147 @@
+/**
+ * Copyright © 2021 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "ups.hpp"
+
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server/manager.hpp>
+#include <sdeventplus/event.hpp>
+#include <sdeventplus/utility/timer.hpp>
+
+#include <chrono>
+
+namespace ibm_ups
+{
+
+using Timer = sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic>;
+
+/**
+ * @class Monitor
+ *
+ * Monitors an Uninterruptible Power Supply (UPS) device.
+ */
+class Monitor
+{
+  public:
+    // Specify which compiler-generated methods we want
+    Monitor() = delete;
+    Monitor(const Monitor&) = delete;
+    Monitor(Monitor&&) = delete;
+    Monitor& operator=(const Monitor&) = delete;
+    Monitor& operator=(Monitor&&) = delete;
+    ~Monitor() = default;
+
+    /**
+     * Constructor.
+     *
+     * Monitoring is enabled by default, polling the UPS device for status.
+     * Call disable() to disable monitoring.
+     *
+     * @param bus D-Bus bus object
+     * @param event event object
+     */
+    explicit Monitor(sdbusplus::bus::bus& bus, const sdeventplus::Event& event);
+
+    /**
+     * Disables monitoring of the UPS device.
+     *
+     * The device will not be polled to obtain the current status.
+     */
+    void disable()
+    {
+        isEnabled = false;
+        stopTimer();
+    }
+
+    /**
+     * Enables monitoring of the UPS device.
+     *
+     * The device will be polled to obtain the current status.
+     */
+    void enable()
+    {
+        isEnabled = true;
+        startTimer();
+    }
+
+  private:
+    /**
+     * Start the timer that polls the UPS device for status.
+     */
+    void startTimer()
+    {
+        // Start timer with repeating 1 second interval
+        timer.restart(std::chrono::seconds(1));
+    }
+
+    /**
+     * Stop the timer that polls the UPS device for status.
+     */
+    void stopTimer()
+    {
+        // Disable timer
+        timer.setEnabled(false);
+    }
+
+    /**
+     * Timer expired callback method.
+     *
+     * Polls the UPS device for status.
+     */
+    void timerExpired()
+    {
+        ups.refresh();
+    }
+
+    /**
+     * D-Bus bus object.
+     */
+    sdbusplus::bus::bus& bus;
+
+    /**
+     * Event object to loop on.
+     */
+    const sdeventplus::Event& eventLoop;
+
+    /**
+     * D-Bus object manager.
+     *
+     * Causes this application to implement the
+     * org.freedesktop.DBus.ObjectManager interface.
+     */
+    sdbusplus::server::manager_t manager;
+
+    /**
+     * UPS device.
+     */
+    UPS ups;
+
+    /**
+     * Indicates whether monitoring is enabled.
+     *
+     * When monitoring is enabled, the UPS device will be polled to obtain the
+     * current status.
+     */
+    bool isEnabled{true};
+
+    /**
+     * Event timer that polls the UPS device for status.
+     */
+    Timer timer;
+};
+
+} // namespace ibm_ups

--- a/ups.cpp
+++ b/ups.cpp
@@ -1,0 +1,353 @@
+/**
+ * Copyright © 2021 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ups.hpp"
+
+#include "error_logging.hpp"
+#include "journal.hpp"
+
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <thread>
+
+namespace ibm_ups
+{
+
+namespace fs = std::filesystem;
+
+/**
+ * D-Bus object path for the UPS.
+ *
+ * The UPower open source package is not used by this application.  However, the
+ * UPower Device interface is used to publish the UPS status on D-Bus.  As a
+ * result, a UPower-style D-Bus object path is used.
+ */
+constexpr auto objectPath = "/org/freedesktop/UPower/devices/ups_hiddev0";
+
+/**
+ * Directory where the UPS character device file should exist.
+ */
+const fs::path deviceDirectory = "/dev";
+
+/**
+ * Expected prefix of the UPS character device file name.
+ */
+constexpr auto deviceNamePrefix = "ttyUSB";
+
+/**
+ * Number of consecutive device read errors before we close the device.
+ *
+ * These errors may indicate the UPS has been removed.
+ */
+constexpr unsigned short maxReadErrorCount{3};
+
+/**
+ * Number of consecutive device reads that must return the same modem bit values
+ * before the values are considered valid.
+ *
+ * This provides de-glitching to ignore a transient event where invalid data is
+ * read.
+ */
+constexpr unsigned short requiredMatchingReadCount{3};
+
+UPS::UPS(sdbusplus::bus::bus& bus) :
+    DeviceObject{bus, objectPath, DeviceObject::action::defer_emit}, bus{bus}
+{
+    // Set D-Bus properties to initial values indicating the UPS is not present.
+    // Skip emitting D-Bus signals until the object has been fully created.
+    bool skipSignals{true};
+    initializeDBusProperties(skipSignals);
+
+    // Read from cable sufficient number of times to determine actual UPS status
+    for (int i = 1; i <= (requiredMatchingReadCount + 1); ++i)
+    {
+        refresh();
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for(50ms);
+    }
+
+    // Emit D-Bus signal that object has been created
+    emit_object_added();
+
+    // Force PropertiesChanged events to be emitted for the three UPS status
+    // properties.  emit_object_added() will cause InterfacesAdded to be
+    // emitted, but some applications only listen for PropertiesChanged.
+    emitIsPresentChangedEvent();
+    emitStateChangedEvent();
+    emitBatteryLevelChangedEvent();
+}
+
+UPS::~UPS()
+{
+    try
+    {
+        if (isDeviceOpen())
+        {
+            closeDevice();
+        }
+    }
+    catch (...)
+    {
+        // Destructors must not throw exceptions
+    }
+}
+
+void UPS::refresh()
+{
+    try
+    {
+        // Open the UPS device if necessary
+        if (!isDeviceOpen())
+        {
+            if (!openDevice())
+            {
+                // Unable to open device; may not be present
+                return;
+            }
+        }
+
+        // Read current status from UPS device
+        readDevice();
+    }
+    catch (...)
+    {
+        // Ignore error in case UPS was removed during the actions above
+    }
+}
+
+void UPS::closeDevice()
+{
+    // Close file descriptor
+    close(fd);
+    fd = INVALID_FD;
+
+    // Clear other data members related to the UPS device
+    devicePath.clear();
+    readErrorCount = 0;
+    matchingReadCount = 0;
+    prevModemBits = INVALID_MODEM_BITS;
+    hasLoggedBatteryDischarging = false;
+    hasLoggedBatteryLow = false;
+
+    // Set D-Bus properties to initial values indicating the UPS is not present
+    initializeDBusProperties();
+}
+
+bool UPS::findDevicePath()
+{
+    devicePath.clear();
+    try
+    {
+        // Loop through all entries in the directory where the file should exist
+        std::string entryName{};
+        for (auto const& entry : fs::directory_iterator{deviceDirectory})
+        {
+            // If entry has expected prefix, exists, and is character device
+            entryName = entry.path().filename().native();
+            if (entryName.starts_with(deviceNamePrefix) && entry.exists() &&
+                entry.is_character_file())
+            {
+                // Found UPS device path
+                devicePath = entry.path();
+                break;
+            }
+        }
+    }
+    catch (...)
+    {
+        // Ignore errors; UPS may have been added/removed during loop
+    }
+    return (!devicePath.empty());
+}
+
+void UPS::handleReadDeviceFailure()
+{
+    // Clear consecutive matching read count and previous modem bits
+    matchingReadCount = 0;
+    prevModemBits = INVALID_MODEM_BITS;
+
+    // Increment consecutive error count
+    if (readErrorCount < maxReadErrorCount)
+    {
+        ++readErrorCount;
+    }
+
+    // If we have reached the maximum number of read errors, close UPS device
+    if (readErrorCount >= maxReadErrorCount)
+    {
+        closeDevice();
+    }
+}
+
+void UPS::handleReadDeviceSuccess(int modemBits)
+{
+    // Clear consecutive read error count
+    readErrorCount = 0;
+
+    // Mask off modem bits that we don't care about
+    modemBits &= (TIOCM_CAR | TIOCM_CTS | TIOCM_DSR);
+
+    // Check if modem bits have changed since the previous read
+    if (modemBits != prevModemBits)
+    {
+        // Modem bits have changed; set matching read count to 1
+        matchingReadCount = 1;
+    }
+    else
+    {
+        // Modem bits have not changed.  Increment matching read count.
+        if (matchingReadCount < requiredMatchingReadCount)
+        {
+            ++matchingReadCount;
+        }
+
+        // If we have reached the required number of matching reads
+        if (matchingReadCount >= requiredMatchingReadCount)
+        {
+            // Get UPS status from modem bit values.
+            bool isOn = static_cast<bool>(modemBits & TIOCM_CAR);
+            bool isBatteryLow = static_cast<bool>(modemBits & TIOCM_CTS);
+            bool isUtilityFail = static_cast<bool>(modemBits & TIOCM_DSR);
+
+            // Log errors or clear error history based on UPS status
+            updateErrorStatus(isBatteryLow, isUtilityFail);
+
+            // Update D-Bus properties with current UPS status
+            updateDBusProperties(isOn, isBatteryLow, isUtilityFail);
+        }
+    }
+
+    // Save the modem bit values for comparison during the next read
+    prevModemBits = modemBits;
+}
+
+void UPS::initializeDBusProperties(bool skipSignals)
+{
+    type(device::type::Ups, skipSignals);
+    powerSupply(true, skipSignals);
+    isPresent(false, skipSignals);
+    state(device::state::FullyCharged, skipSignals);
+    isRechargeable(true, skipSignals);
+    batteryLevel(device::battery_level::Full, skipSignals);
+}
+
+bool UPS::openDevice()
+{
+    bool wasOpened{false};
+
+    // Find UPS device path
+    if (findDevicePath())
+    {
+        // Open device path
+        int rc = open(devicePath.c_str(), O_RDONLY);
+        if (rc >= 0)
+        {
+            fd = rc;
+            wasOpened = true;
+        }
+    }
+
+    return wasOpened;
+}
+
+void UPS::readDevice()
+{
+    // Read modem bits from device driver
+    int modemBits{0};
+    int rc = ioctl(fd, TIOCMGET, &modemBits);
+    if (rc < 0)
+    {
+        handleReadDeviceFailure();
+    }
+    else
+    {
+        handleReadDeviceSuccess(modemBits);
+    }
+}
+
+void UPS::updateDBusProperties(bool isOn, bool isBatteryLow, bool isUtilityFail)
+{
+    // Set D-Bus IsPresent property.  isOn means UPS is present/functional.
+    isPresent(isOn);
+
+    // Set D-Bus State property
+    if (isUtilityFail)
+    {
+        // Utility failure is occurring.  UPS is providing power to the system.
+        state(device::state::Discharging);
+    }
+    else if (isBatteryLow)
+    {
+        // UPS is not providing power to the system, but the battery is low.
+        // Assume the battery is charging.
+        state(device::state::Charging);
+    }
+    else
+    {
+        // UPS is not providing power to the system, and battery is not low.
+        // Assume the battery is fully charged.
+        state(device::state::FullyCharged);
+    }
+
+    // Set D-Bus BatteryLevel property
+    batteryLevel(isBatteryLow ? device::battery_level::Low
+                              : device::battery_level::Full);
+}
+
+void UPS::updateErrorStatus(bool isBatteryLow, bool isUtilityFail)
+{
+    // Check if utility failure is occurring, causing UPS battery to discharge
+    if (isUtilityFail)
+    {
+        // Log error if one was not already logged
+        if (!hasLoggedBatteryDischarging)
+        {
+            journal::logError(
+                "UPS battery discharging due to utility failure: " +
+                devicePath.native());
+            error_logging::logBatteryDischarging(bus, devicePath.native());
+            hasLoggedBatteryDischarging = true;
+        }
+    }
+    else
+    {
+        // Clear error history since battery is no longer discharging
+        hasLoggedBatteryDischarging = false;
+    }
+
+    // Check if the UPS battery level is low
+    if (isBatteryLow)
+    {
+        // Log error if one was not already logged
+        if (!hasLoggedBatteryLow)
+        {
+            journal::logError("UPS battery level is low: " +
+                              devicePath.native());
+            error_logging::logBatteryLow(bus, devicePath.native());
+            hasLoggedBatteryLow = true;
+        }
+    }
+    else
+    {
+        // Clear error history since battery level is no longer low
+        hasLoggedBatteryLow = false;
+    }
+}
+
+} // namespace ibm_ups

--- a/ups.hpp
+++ b/ups.hpp
@@ -1,0 +1,283 @@
+/**
+ * Copyright © 2021 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "device.hpp"
+
+#include <sdbusplus/bus.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace ibm_ups
+{
+
+/**
+ * @class UPS
+ *
+ * This class represents an Uninterruptible Power Supply (UPS) device.
+ *
+ * The UPS must be connected to the system using an IBM System Port Converter
+ * Cable.  This USB cable allows for communications from a UPS relay interface
+ * card to a BMC USB port.
+ *
+ * The UPS status is read from the USB cable.  The status is published on D-Bus
+ * using the UPower Device interface.
+ *
+ * The PLDM application uses the D-Bus information to build PLDM state sensors.
+ * These state sensors communicate the UPS status to the host operating system.
+ *
+ * If a UPS is not connected to the system, the IsPresent property of the D-Bus
+ * interface is set to false.  The D-Bus object for the UPS always exists.  This
+ * is required due to the way PLDM maps the D-Bus interface properties into PLDM
+ * state sensors.
+ */
+class UPS : public DeviceObject
+{
+  public:
+    // Specify which compiler-generated methods we want
+    UPS() = delete;
+    UPS(const UPS&) = delete;
+    UPS(UPS&&) = delete;
+    UPS& operator=(const UPS&) = delete;
+    UPS& operator=(UPS&&) = delete;
+
+    /**
+     * Constructor.
+     *
+     * @param bus D-Bus bus object
+     */
+    explicit UPS(sdbusplus::bus::bus& bus);
+
+    /**
+     * Destructor.
+     *
+     * Closes the UPS device if necessary.
+     */
+    virtual ~UPS();
+
+    /**
+     * Refreshes the UPS device status by reading from the UPS cable.
+     */
+    virtual void refresh() override;
+
+    /**
+     * Gets history for the UPS device that is persistent across reboots.
+     *
+     * This method from the Device interface is not supported.  History is not
+     * available from the USB cable interface.
+     */
+    virtual std::vector<std::tuple<uint32_t, double, uint32_t>>
+        getHistory(std::string /*type*/, uint32_t /*timespan*/,
+                   uint32_t /*resolution*/) override
+    {
+        return std::vector<std::tuple<uint32_t, double, uint32_t>>{};
+    }
+
+    /**
+     * Gets statistics for the UPS device.
+     *
+     * This method from the Device interface is not supported.  Statistics are
+     * not available from the USB cable interface.
+     */
+    virtual std::vector<std::tuple<double, double>>
+        getStatistics(std::string /*type*/) override
+    {
+        return std::vector<std::tuple<double, double>>{};
+    }
+
+  private:
+    /**
+     * Close the UPS device.
+     */
+    void closeDevice();
+
+    /**
+     * Force a PropertiesChanged event to be emitted for the BatteryLevel
+     * property.
+     */
+    void emitBatteryLevelChangedEvent()
+    {
+        // Save current value, change property without emitting a signal, and
+        // then change back to the saved value.  There is no direct way to force
+        // the signal to be emitted using the sdbusplus API.
+        bool skipSignal{true};
+        uint32_t value = batteryLevel();
+        batteryLevel(device::battery_level::Unknown, skipSignal);
+        batteryLevel(value);
+    }
+
+    /**
+     * Force a PropertiesChanged event to be emitted for the IsPresent property.
+     */
+    void emitIsPresentChangedEvent()
+    {
+        // Save current value, change property without emitting a signal, and
+        // then change back to the saved value.  There is no direct way to force
+        // the signal to be emitted using the sdbusplus API.
+        bool skipSignal{true};
+        bool value = isPresent();
+        isPresent(!value, skipSignal);
+        isPresent(value);
+    }
+
+    /**
+     * Force a PropertiesChanged event to be emitted for the State property.
+     */
+    void emitStateChangedEvent()
+    {
+        // Save current value, change property without emitting a signal, and
+        // then change back to the saved value.  There is no direct way to force
+        // the signal to be emitted using the sdbusplus API.
+        bool skipSignal{true};
+        uint32_t value = state();
+        state(device::state::Unknown, skipSignal);
+        state(value);
+    }
+
+    /**
+     * Find the file system path to the UPS device.
+     *
+     * If found, the path is stored in the devicePath data member.
+     *
+     * @return true if file system path was found, false otherwise
+     */
+    bool findDevicePath();
+
+    /**
+     * Handle a failed attempt to read current status from the UPS device.
+     */
+    void handleReadDeviceFailure();
+
+    /**
+     * Handle a successful attempt to read current status from the UPS device.
+     *
+     * @param modemBits modem bit values read from the device
+     */
+    void handleReadDeviceSuccess(int modemBits);
+
+    /**
+     * Set D-Bus properties to initial values indicating the UPS is not present.
+     *
+     * @param skipSignals indicates whether to skip emitting D-Bus property
+     *                    changed signals
+     */
+    void initializeDBusProperties(bool skipSignals = false);
+
+    /**
+     * Returns whether the UPS device has been opened.
+     *
+     * @return true if device is open, false otherwise
+     */
+    bool isDeviceOpen()
+    {
+        return (fd != INVALID_FD);
+    }
+
+    /**
+     * Open the UPS device.
+     *
+     * @return true if device was opened, false otherwise
+     */
+    bool openDevice();
+
+    /**
+     * Read current status from the UPS device.
+     */
+    void readDevice();
+
+    /**
+     * Update D-Bus properties with the current status read from the UPS device.
+     *
+     * @param isOn specifies whether the UPS device is present/functional
+     * @param isBatteryLow specifies whether the UPS battery level is low
+     * @param isUtilityFail specifies whether the UPS is providing power
+     *                      to the system due to a utility failure
+     */
+    void updateDBusProperties(bool isOn, bool isBatteryLow, bool isUtilityFail);
+
+    /**
+     * Update the error status of the UPS device.
+     *
+     * Log errors or clear error history based on the current UPS status.
+     *
+     * @param isBatteryLow specifies whether the UPS battery level is low
+     * @param isUtilityFail specifies whether the UPS is providing power
+     *                      to the system due to a utility failure
+     */
+    void updateErrorStatus(bool isBatteryLow, bool isUtilityFail);
+
+    /**
+     * Invalid value for a file descriptor.
+     */
+    static constexpr int INVALID_FD{-1};
+
+    /**
+     * Invalid value for the modem bits read from the UPS device.
+     */
+    static constexpr int INVALID_MODEM_BITS{-1};
+
+    /**
+     * D-Bus bus object.
+     */
+    sdbusplus::bus::bus& bus;
+
+    /**
+     * File system path to the UPS device.
+     */
+    std::filesystem::path devicePath{};
+
+    /**
+     * File descriptor for the UPS device.
+     */
+    int fd{INVALID_FD};
+
+    /**
+     * Number of consecutive device reads that have failed with an error.
+     */
+    unsigned short readErrorCount{0};
+
+    /**
+     * Number of consecutive device reads that have returned the same modem bit
+     * values.
+     *
+     * This provides de-glitching to ignore a transient event where invalid data
+     * is read.
+     */
+    unsigned short matchingReadCount{0};
+
+    /**
+     * Modem bits previously read from the UPS device.
+     */
+    int prevModemBits{INVALID_MODEM_BITS};
+
+    /**
+     * Indicates whether an error has been logged because the UPS battery
+     * is discharging due to a utility failure.
+     */
+    bool hasLoggedBatteryDischarging{false};
+
+    /**
+     * Indicates whether an error has been logged because the UPS battery
+     * level is low.
+     */
+    bool hasLoggedBatteryLow{false};
+};
+
+} // namespace ibm_ups


### PR DESCRIPTION
The ibm-ups application was previously located in the public downstream fork (ibm-openbmc) of the phosphor-power repository.

The application is being moved to the new ibm-ups repository.

Copy the following ibm-ups files from phosphor-power:
* Source files (*.hpp/*.cpp)
* Service file
* meson.build file

Add some basic information to the README.md file